### PR TITLE
use $GITHUB_OUTPUT path instead of special output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ runs:
         }
 
         $connstring = ${{ github.action_path }}/main.ps1 @params
-        Write-Output "::set-output name=connstring::$connstring"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "connstring=$connstring"
 outputs:
   connstring:
     description: "Connection string"


### PR DESCRIPTION
The use of `::set-output` in stdout is deprecated https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, this PR fixes the warnings generated by this action by using the new supported way: writing to the `$GITHUB_OUTPUT` file